### PR TITLE
Implement feedback: hover behaviour, scaling font, custom speed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,16 +36,17 @@ Each of these has a co-located `*.test.js` (Vitest). Keep this layer Electron-fr
 - **store.js** — load/save state via `normalizeState`.
 - **dictionaries.js** — import/delete/list custom dictionaries.
 - **phraseEngine.js** — owns the phrase list, current index and auto-advance timer; surface-agnostic via an injected `onRender(phrase, index, total)`.
-- **windows.js** — main/import/about window factories (`securePreferences()` wires the preload + isolation flags).
+- **windows.js** — main/import/about/custom-speed window factories (`securePreferences()` wires the preload + isolation flags).
 - **tray.js** — a **single** tray-menu template builder used for both creation and every refresh (do not reintroduce a second copy).
 - **ipc.js** — registers the whitelisted `ipcMain` handlers.
 
 [index.js](index.js) is the thin composition root: it holds the `state` object, creates the engine/tray/windows, wires tray actions and IPC callbacks, and owns app lifecycle. `renderPhrase` routes the current phrase to the tray title (Menu Bar mode) or the window (otherwise).
 
 ### `src/preload/` and `src/renderer/`
-- **preload/{main,import,about}.js** — expose `window.vocab` per window.
-- **renderer/main.js** — main display window logic (phrase rendering, fade animation, TTS via `SpeechSynthesisUtterance`, progress bar, theme).
-- HTML lives at the project root (`index.html`, `import.html`, `about.html`); `import.html`/`about.html` keep small inline scripts.
+- **preload/{main,import,about,speed}.js** — expose `window.vocab` per window.
+- **renderer/main.js** — main display window logic (phrase rendering, fade animation, TTS via `SpeechSynthesisUtterance`, progress bar, theme). Auto-advance **pauses while the window is hovered** (`setPaused` → engine stop/restart) and the keyboard hint only shows on hover. The target font scales with the window via CSS `clamp(.., vw, ..)`.
+- **renderer/speed.js** — the custom-speed prompt.
+- HTML lives at the project root (`index.html`, `import.html`, `about.html`, `speed.html`); `import.html`/`about.html` keep small inline scripts.
 
 ### Key cross-cutting concepts
 - **Modes** (`MODES`): `Window`, `Menu Bar` (tray title, macOS only), `Checkup` (shows the source word, reveals the translation after 3s), `Sound` (TTS). Mode switching is gated to `process.platform === 'darwin'`.

--- a/index.html
+++ b/index.html
@@ -51,12 +51,13 @@
         animation: phrase-in 0.32s ease;
       }
       #source {
-        font-size: 15px;
+        /* Scales with the window width so a larger window means larger text. */
+        font-size: clamp(13px, 3vw, 28px);
         font-weight: 500;
         color: var(--muted);
       }
       #target {
-        font-size: 30px;
+        font-size: clamp(22px, 7.5vw, 80px);
         font-weight: 650;
         letter-spacing: -0.01em;
         line-height: 1.15;
@@ -78,13 +79,14 @@
       }
 
       #hint {
-        font-size: 11.5px;
+        font-size: clamp(10px, 2.2vw, 15px);
         color: var(--muted);
-        opacity: 0.85;
-        transition: opacity 0.6s ease;
-      }
-      #hint.faded {
         opacity: 0;
+        transition: opacity 0.3s ease;
+      }
+      /* The hint stays out of the way and only appears while hovering. */
+      body:hover #hint {
+        opacity: 0.85;
       }
       #hint kbd {
         font-family: inherit;
@@ -115,7 +117,7 @@
         transition: width 0.3s ease;
       }
       #progress-label {
-        font-size: 11px;
+        font-size: clamp(10px, 2vw, 15px);
         color: var(--muted);
         font-variant-numeric: tabular-nums;
       }

--- a/index.js
+++ b/index.js
@@ -3,10 +3,11 @@ const { app, BrowserWindow, dialog, globalShortcut, shell } = require('electron'
 const { MODES, IPC } = require('./src/shared/constants');
 const { getLanguageFilePath, parseCustomDictName, getLocale } = require('./src/shared/languagePaths');
 const { CUSTOM_DICTS_PATH, getDictionariesBasePath, ensureCustomDictsDir } = require('./src/main/config');
+const { clampInterval } = require('./src/shared/state');
 const { loadState, saveState } = require('./src/main/store');
 const dictionaries = require('./src/main/dictionaries');
 const { createPhraseEngine } = require('./src/main/phraseEngine');
-const { createMainWindow, createImportWindow, createAboutWindow } = require('./src/main/windows');
+const { createMainWindow, createImportWindow, createSpeedWindow, createAboutWindow } = require('./src/main/windows');
 const { createTrayController } = require('./src/main/tray');
 const { registerIpcHandlers } = require('./src/main/ipc');
 
@@ -14,6 +15,7 @@ let state = loadState();
 let mainWindow = null;
 let engine;
 let tray;
+let isHoverPaused = false;
 
 function showError(message, error) {
   dialog.showErrorBox(message, error ? error.stack || error.toString() : 'Unknown error');
@@ -138,7 +140,20 @@ function handleKeyPress(keyEvent) {
   } else {
     engine.previous();
   }
-  engine.restartTimer();
+  // Don't resume auto-advance if the pointer is still hovering the window.
+  if (!isHoverPaused) {
+    engine.restartTimer();
+  }
+}
+
+// Pauses auto-advance while the window is hovered; the current word stays put.
+function setHoverPaused(paused) {
+  isHoverPaused = paused;
+  if (paused) {
+    engine.stop();
+  } else {
+    engine.restartTimer();
+  }
 }
 
 function registerGlobalShortcuts() {
@@ -197,6 +212,7 @@ app.whenReady().then(() => {
       setSpeed,
       toggleSound,
       openImport: () => createImportWindow(),
+      openCustomSpeed: () => createSpeedWindow(),
       openAbout: () => createAboutWindow(),
       deleteDictionary: deleteDictionaryAction,
       quit: quitApp
@@ -226,7 +242,10 @@ app.whenReady().then(() => {
         shell.openExternal(url);
       }
     },
-    onKeyPress: handleKeyPress
+    onKeyPress: handleKeyPress,
+    onSetPaused: setHoverPaused,
+    getIntervalMs: () => state.intervalMs,
+    setCustomSpeed: seconds => setSpeed(clampInterval(seconds * 1000))
   });
 
   createWiredMainWindow();

--- a/speed.html
+++ b/speed.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Custom Speed</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        margin: 24px;
+        color: #1d1d1f;
+      }
+      h1 {
+        font-size: 1.25em;
+        margin: 0 0 6px;
+      }
+      p {
+        font-size: 13px;
+        color: #555;
+        margin: 0 0 18px;
+      }
+      label {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 13px;
+        font-weight: 600;
+      }
+      input {
+        display: block;
+        width: 100%;
+        padding: 9px 10px;
+        font-size: 14px;
+        border: 1px solid #ccc;
+        border-radius: 8px;
+        margin-bottom: 18px;
+      }
+      button {
+        width: 100%;
+        padding: 10px;
+        font-size: 14px;
+        font-weight: 600;
+        border: none;
+        border-radius: 8px;
+        background: #1f6feb;
+        color: #fff;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+      button:hover {
+        background: #1a5fd0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Custom Speed</h1>
+    <p>How many seconds each word stays on screen (1–600).</p>
+    <label for="seconds">Seconds</label>
+    <input type="number" id="seconds" min="1" max="600" step="1" />
+    <button id="saveButton">Save</button>
+    <script src="src/renderer/speed.js"></script>
+  </body>
+</html>

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -4,11 +4,22 @@ const { IPC } = require('../shared/constants');
 // Registers the main-process side of the IPC contract. Only the channels
 // the app actually uses are wired up; each delegates to a callback the
 // composition root provides.
-function registerIpcHandlers({ importDictionary, chooseDictionaryFile, openExternal, onKeyPress }) {
+function registerIpcHandlers({
+  importDictionary,
+  chooseDictionaryFile,
+  openExternal,
+  onKeyPress,
+  onSetPaused,
+  getIntervalMs,
+  setCustomSpeed
+}) {
   ipcMain.handle(IPC.IMPORT_DICTIONARY, (event, payload) => importDictionary(payload));
   ipcMain.handle(IPC.CHOOSE_DICTIONARY_FILE, () => chooseDictionaryFile());
   ipcMain.handle(IPC.OPEN_EXTERNAL, (event, url) => openExternal(url));
+  ipcMain.handle(IPC.GET_INTERVAL, () => getIntervalMs());
+  ipcMain.handle(IPC.SET_CUSTOM_SPEED, (event, seconds) => setCustomSpeed(seconds));
   ipcMain.on(IPC.KEY_PRESS, (event, keyEvent) => onKeyPress(keyEvent));
+  ipcMain.on(IPC.SET_PAUSED, (event, paused) => onSetPaused(paused));
 }
 
 module.exports = { registerIpcHandlers };

--- a/src/main/tray.js
+++ b/src/main/tray.js
@@ -117,12 +117,22 @@ function createTrayController({ getState, actions, dictionaries }) {
   }
 
   function speedSubmenu(state) {
-    return SPEED_INTERVALS.map(ms => ({
-      label: `${ms / 1000} seconds`,
-      type: 'radio',
-      checked: state.intervalMs === ms,
-      click: () => actions.setSpeed(ms)
-    }));
+    const isCustom = !SPEED_INTERVALS.includes(state.intervalMs);
+    return [
+      ...SPEED_INTERVALS.map(ms => ({
+        label: `${ms / 1000} seconds`,
+        type: 'radio',
+        checked: state.intervalMs === ms,
+        click: () => actions.setSpeed(ms)
+      })),
+      { type: 'separator' },
+      {
+        label: isCustom ? `Custom… (${state.intervalMs / 1000}s)` : 'Custom…',
+        type: 'radio',
+        checked: isCustom,
+        click: () => actions.openCustomSpeed()
+      }
+    ];
   }
 
   function deleteSubmenu() {

--- a/src/main/windows.js
+++ b/src/main/windows.js
@@ -56,6 +56,18 @@ function createImportWindow() {
   return win;
 }
 
+function createSpeedWindow() {
+  const win = new BrowserWindow({
+    width: 360,
+    height: 260,
+    resizable: false,
+    title: 'Custom Speed',
+    webPreferences: securePreferences('speed.js')
+  });
+  win.loadFile(htmlPath('speed.html'));
+  return win;
+}
+
 // The About window is a singleton: re-invoking focuses the existing one.
 let aboutWindow = null;
 
@@ -85,5 +97,6 @@ function createAboutWindow() {
 module.exports = {
   createMainWindow,
   createImportWindow,
+  createSpeedWindow,
   createAboutWindow
 };

--- a/src/preload/main.js
+++ b/src/preload/main.js
@@ -18,5 +18,6 @@ contextBridge.exposeInMainWorld('vocab', {
       callback({ fromLocale, toLocale })
     ),
   onClearTimeouts: callback => ipcRenderer.on(IPC.CLEAR_TIMEOUTS, () => callback()),
-  sendKeyPress: keyEvent => ipcRenderer.send(IPC.KEY_PRESS, keyEvent)
+  sendKeyPress: keyEvent => ipcRenderer.send(IPC.KEY_PRESS, keyEvent),
+  setPaused: paused => ipcRenderer.send(IPC.SET_PAUSED, paused)
 });

--- a/src/preload/speed.js
+++ b/src/preload/speed.js
@@ -1,0 +1,8 @@
+const { contextBridge, ipcRenderer } = require('electron');
+const { IPC } = require('../shared/constants');
+
+// API for the Custom Speed window: read the current interval and set a new one.
+contextBridge.exposeInMainWorld('vocab', {
+  getIntervalMs: () => ipcRenderer.invoke(IPC.GET_INTERVAL),
+  setCustomSpeed: seconds => ipcRenderer.invoke(IPC.SET_CUSTOM_SPEED, seconds)
+});

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,12 +1,10 @@
 const phraseContainer = document.getElementById('phrase-container');
 const sourceEl = document.getElementById('source');
 const targetEl = document.getElementById('target');
-const hintEl = document.getElementById('hint');
 const progressBarInner = document.getElementById('progress-bar-inner');
 const progressLabel = document.getElementById('progress-label');
 
 const PHRASE_SEPARATOR = ' - ';
-const HINT_FADE_DELAY_MS = 6000;
 
 let isSoundMode = false;
 let fromLocale = 'de-DE';
@@ -51,6 +49,20 @@ function replayEnterAnimation() {
   phraseContainer.style.animation = '';
 }
 
+// Hides the answer instantly (no fade), so a new Checkup word never flashes
+// its translation before hiding it.
+function hideTarget() {
+  targetEl.style.transition = 'none';
+  targetEl.classList.add('hidden');
+  void targetEl.offsetWidth; // commit the hidden state before any paint
+}
+
+// Reveals the answer with the normal fade-in transition.
+function revealTarget() {
+  targetEl.style.transition = '';
+  targetEl.classList.remove('hidden');
+}
+
 function displayPhrase({ phrase, mode, index, total }) {
   clearRevealTimeout();
   updateProgressBar(index, total);
@@ -61,28 +73,22 @@ function displayPhrase({ phrase, mode, index, total }) {
   targetEl.textContent = target;
 
   if (mode === 'Checkup' && target) {
-    // Hide the answer, then reveal it after a short delay.
-    targetEl.classList.add('hidden');
+    hideTarget();
     speak(source, fromLocale);
     revealTimeoutId = setTimeout(() => {
-      targetEl.classList.remove('hidden');
+      revealTarget();
       speak(target, toLocale);
     }, 3000);
     return;
   }
 
-  targetEl.classList.remove('hidden');
+  revealTarget();
   if (target) {
     speak(source, fromLocale);
     revealTimeoutId = setTimeout(() => speak(target, toLocale), 2000);
   } else {
     speak(source, toLocale);
   }
-}
-
-function scheduleHintFade() {
-  hintEl.classList.remove('faded');
-  setTimeout(() => hintEl.classList.add('faded'), HINT_FADE_DELAY_MS);
 }
 
 window.vocab.onSetLanguages(({ fromLocale: from, toLocale: to }) => {
@@ -105,4 +111,7 @@ document.addEventListener('keydown', event => {
   window.vocab.sendKeyPress({ shiftKey: event.shiftKey, key: event.key });
 });
 
-scheduleHintFade();
+// Pause auto-advance while the pointer is over the window so the user can
+// read the current word; resume on leave.
+document.documentElement.addEventListener('mouseenter', () => window.vocab.setPaused(true));
+document.documentElement.addEventListener('mouseleave', () => window.vocab.setPaused(false));

--- a/src/renderer/speed.js
+++ b/src/renderer/speed.js
@@ -1,0 +1,16 @@
+const secondsInput = document.getElementById('seconds');
+const saveButton = document.getElementById('saveButton');
+
+// Prefill with the currently active interval.
+window.vocab.getIntervalMs().then(intervalMs => {
+  secondsInput.value = Math.round(intervalMs / 1000);
+});
+
+saveButton.addEventListener('click', async () => {
+  const seconds = Number(secondsInput.value);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return;
+  }
+  await window.vocab.setCustomSpeed(seconds);
+  window.close();
+});

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -52,9 +52,12 @@ const IPC = Object.freeze({
   SET_LANGUAGES: 'set-languages',
   CLEAR_TIMEOUTS: 'clear-timeouts',
   KEY_PRESS: 'key-press',
+  SET_PAUSED: 'set-paused',
   IMPORT_DICTIONARY: 'import-dictionary',
   CHOOSE_DICTIONARY_FILE: 'choose-dictionary-file',
-  OPEN_EXTERNAL: 'open-external'
+  OPEN_EXTERNAL: 'open-external',
+  GET_INTERVAL: 'get-interval',
+  SET_CUSTOM_SPEED: 'set-custom-speed'
 });
 
 module.exports = {

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -1,4 +1,8 @@
-const { MODES, DEFAULT_INTERVAL_MS, SPEED_INTERVALS } = require('./constants');
+const { MODES, DEFAULT_INTERVAL_MS } = require('./constants');
+
+// Bounds for a (possibly custom) word-change interval: 1s to 10 minutes.
+const MIN_INTERVAL_MS = 1000;
+const MAX_INTERVAL_MS = 600000;
 
 // The persisted application state and its defaults. Defaults are applied
 // whenever a field is missing or invalid, so a partial/corrupt config file
@@ -43,10 +47,25 @@ function normalizeState(raw) {
     currentBackground: VALID_BACKGROUNDS.has(source.currentBackground)
       ? source.currentBackground
       : DEFAULT_STATE.currentBackground,
-    intervalMs: SPEED_INTERVALS.includes(source.intervalMs)
+    intervalMs: isValidInterval(source.intervalMs)
       ? source.intervalMs
       : DEFAULT_STATE.intervalMs
   };
+}
+
+// Accepts any whole-millisecond interval within bounds, so custom speeds
+// (not just the tray presets) persist correctly.
+function isValidInterval(value) {
+  return Number.isInteger(value) && value >= MIN_INTERVAL_MS && value <= MAX_INTERVAL_MS;
+}
+
+// Clamps an arbitrary interval (e.g. from the custom-speed input) into the
+// supported range; non-numbers fall back to the default.
+function clampInterval(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return DEFAULT_INTERVAL_MS;
+  }
+  return Math.min(Math.max(Math.round(value), MIN_INTERVAL_MS), MAX_INTERVAL_MS);
 }
 
 function isNonEmptyString(value) {
@@ -59,5 +78,8 @@ function isNonNegativeInt(value) {
 
 module.exports = {
   DEFAULT_STATE,
-  normalizeState
+  MIN_INTERVAL_MS,
+  MAX_INTERVAL_MS,
+  normalizeState,
+  clampInterval
 };

--- a/src/shared/state.test.js
+++ b/src/shared/state.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeState, DEFAULT_STATE } from './state.js';
+import { normalizeState, DEFAULT_STATE, clampInterval, MIN_INTERVAL_MS, MAX_INTERVAL_MS } from './state.js';
 
 describe('normalizeState', () => {
   it('returns the defaults for empty / non-object input', () => {
@@ -27,7 +27,7 @@ describe('normalizeState', () => {
       currentIndex: -3,
       currentMode: 'Bogus',
       currentBackground: 'rainbow',
-      intervalMs: 1234,
+      intervalMs: 0, // below the minimum
       isSoundMode: 'yes'
     });
     expect(result.currentIndex).toBe(DEFAULT_STATE.currentIndex);
@@ -37,7 +37,34 @@ describe('normalizeState', () => {
     expect(result.isSoundMode).toBe(DEFAULT_STATE.isSoundMode);
   });
 
+  it('preserves a custom (non-preset) interval within bounds', () => {
+    expect(normalizeState({ intervalMs: 7000 }).intervalMs).toBe(7000);
+  });
+
+  it('rejects an out-of-range interval', () => {
+    expect(normalizeState({ intervalMs: MAX_INTERVAL_MS + 1 }).intervalMs).toBe(DEFAULT_STATE.intervalMs);
+  });
+
   it('preserves a custom level string', () => {
     expect(normalizeState({ currentLevel: 'custom:travel' }).currentLevel).toBe('custom:travel');
+  });
+});
+
+describe('clampInterval', () => {
+  it('clamps below the minimum up to the minimum', () => {
+    expect(clampInterval(10)).toBe(MIN_INTERVAL_MS);
+  });
+
+  it('clamps above the maximum down to the maximum', () => {
+    expect(clampInterval(10_000_000)).toBe(MAX_INTERVAL_MS);
+  });
+
+  it('rounds and passes through an in-range value', () => {
+    expect(clampInterval(7000.4)).toBe(7000);
+  });
+
+  it('falls back to the default for non-numbers', () => {
+    expect(clampInterval(NaN)).toBe(DEFAULT_STATE.intervalMs);
+    expect(clampInterval('5000')).toBe(DEFAULT_STATE.intervalMs);
   });
 });


### PR DESCRIPTION
Addresses the GitHub feedback issue:

1. Hint only shows on hover (was: faded out after a few seconds).
2. Font scales with the window — source/target/hint/progress use CSS clamp(min, vw, max) so a larger window means larger text.
3. Custom changing speed: tray "Changing speed" gains a "Custom…" item that opens a small prompt window (1–600s). State validation now accepts any in-range interval (clampInterval/isValidInterval), not just the presets, so custom speeds persist.
5. Auto-advance pauses while the pointer is over the window and resumes on leave (SET_PAUSED ipc -> engine stop/restart; keyboard navigation won't resume the timer while still hovered).

(4 — word ID in the window — was already resolved earlier; only an unobtrusive progress counter remains at the bottom.)

Also fixes a Checkup-mode flash: the translation briefly appeared before being hidden because the hidden class animated opacity. It is now hidden instantly and only the reveal fades in.

Tests: state interval validation + clampInterval covered (32 passing).